### PR TITLE
Remove API that appears to be unnecessary with immutable types

### DIFF
--- a/src/main/template/float/org/spongepowered/math/imaginary/Complex{{E}}.java.peb
+++ b/src/main/template/float/org/spongepowered/math/imaginary/Complex{{E}}.java.peb
@@ -25,19 +25,13 @@ public final class Complex{{ E }} implements Imaginary{{ E }}, Comparable<Comple
      * An immutable identity (1, 0) complex.
      */
     public static final Complex{{ E }} IDENTITY = new Complex{{ E }}(1, 0);
+
     private final {{ e }} x;
     private final {{ e }} y;
     @SuppressWarnings("Immutable")
     private transient volatile boolean hashed = false;
     @SuppressWarnings("Immutable")
     private transient volatile int hashCode = 0;
-
-    /**
-     * Constructs a new complex. The components are set to the identity (1, 0).
-     */
-    public Complex{{ E }}() {
-        this(1, 0);
-    }
 
     /**
      * Constructs a new complex from the {{ EOverload }} components.

--- a/src/main/template/float/org/spongepowered/math/imaginary/Complex{{E}}.java.peb
+++ b/src/main/template/float/org/spongepowered/math/imaginary/Complex{{E}}.java.peb
@@ -14,7 +14,7 @@ import org.spongepowered.math.vector.Vector3{{ E }};
  * Represent a complex number of the form {@code x + yi}. The x and y components are stored as {@code {{ e }}}s. This class is immutable.
  */
 @Immutable
-public final class Complex{{ E }} implements Imaginary{{ E }}, Comparable<Complex{{ E }}>, Serializable, Cloneable {
+public final class Complex{{ E }} implements Imaginary{{ E }}, Comparable<Complex{{ E }}>, Serializable {
 
     private static final long serialVersionUID = 1;
     /**
@@ -58,16 +58,6 @@ public final class Complex{{ E }} implements Imaginary{{ E }}, Comparable<Comple
     public Complex{{ E }}(final {{ e }} x, final {{ e }} y) {
         this.x = x;
         this.y = y;
-    }
-
-    /**
-     * Copy constructor.
-     *
-     * @param c The complex to copy
-     */
-    public Complex{{ E }}(final Complex{{ E }} c) {
-        this.x = c.x;
-        this.y = c.y;
     }
 
     /**
@@ -511,11 +501,6 @@ public final class Complex{{ E }} implements Imaginary{{ E }}, Comparable<Comple
     @Override
     public int compareTo(final Complex{{ E }} that) {
         return (int) Math.signum(this.lengthSquared() - that.lengthSquared());
-    }
-
-    @Override
-    public Complex{{ E }} clone() {
-        return new Complex{{ E }}(this);
     }
 
     @Override

--- a/src/main/template/float/org/spongepowered/math/imaginary/Quaternion{{E}}.java.peb
+++ b/src/main/template/float/org/spongepowered/math/imaginary/Quaternion{{E}}.java.peb
@@ -36,13 +36,6 @@ public final class Quaternion{{ E }} implements Imaginary{{ E }}, Comparable<Qua
     private transient volatile int hashCode = 0;
 
     /**
-     * Constructs a new quaternion. The components are set to the identity (0, 0, 0, 1).
-     */
-    public Quaternion{{ E }}() {
-        this(0, 0, 0, 1);
-    }
-
-    /**
      * Constructs a new quaternion from the {{ EOverload }} components.
      *
      * @param x The x (imaginary) component

--- a/src/main/template/float/org/spongepowered/math/imaginary/Quaternion{{E}}.java.peb
+++ b/src/main/template/float/org/spongepowered/math/imaginary/Quaternion{{E}}.java.peb
@@ -15,7 +15,7 @@ import org.spongepowered.math.vector.Vector3{{ E }};
  * immutable.</p>
  */
 @Immutable
-public final class Quaternion{{ E }} implements Imaginary{{ E }}, Comparable<Quaternion{{ E }}>, Serializable, Cloneable {
+public final class Quaternion{{ E }} implements Imaginary{{ E }}, Comparable<Quaternion{{ E }}>, Serializable {
 
     private static final long serialVersionUID = 1;
     /**
@@ -67,15 +67,6 @@ public final class Quaternion{{ E }} implements Imaginary{{ E }}, Comparable<Qua
         this.y = y;
         this.z = z;
         this.w = w;
-    }
-
-    /**
-     * Copy constructor.
-     *
-     * @param q The quaternion to copy
-     */
-    public Quaternion{{ E }}(final Quaternion{{ E }} q) {
-        this(q.x, q.y, q.z, q.w);
     }
 
     /**
@@ -577,11 +568,6 @@ public final class Quaternion{{ E }} implements Imaginary{{ E }}, Comparable<Qua
     @Override
     public int compareTo(final Quaternion{{ E }} q) {
         return (int) Math.signum(this.lengthSquared() - q.lengthSquared());
-    }
-
-    @Override
-    public Quaternion{{ E }} clone() {
-        return new Quaternion{{ E }}(this);
     }
 
     @Override

--- a/src/main/template/float/org/spongepowered/math/matrix/Matrix2{{E}}.java.peb
+++ b/src/main/template/float/org/spongepowered/math/matrix/Matrix2{{E}}.java.peb
@@ -17,21 +17,19 @@ public final class Matrix2{{ E }} implements Matrix{{ E }}, Serializable {
 
     private static final long serialVersionUID = 1;
     public static final Matrix2{{ E }} ZERO = new Matrix2{{ E }}(
-            0, 0,
-            0, 0);
-    public static final Matrix2{{ E }} IDENTITY = new Matrix2{{ E }}();
+        0, 0,
+        0, 0
+    );
+    public static final Matrix2{{ E }} IDENTITY = new Matrix2{{ E }}(
+        1, 0,
+        0, 1
+    );
     private final {{ e }} m00, m01;
     private final {{ e }} m10, m11;
     @SuppressWarnings("Immutable")
     private transient volatile boolean hashed = false;
     @SuppressWarnings("Immutable")
     private transient volatile int hashCode = 0;
-
-    public Matrix2{{ E }}() {
-        this(
-                1, 0,
-                0, 1);
-    }
 
     public Matrix2{{ E }}(final Matrix3{{ E }} m) {
         this(

--- a/src/main/template/float/org/spongepowered/math/matrix/Matrix2{{E}}.java.peb
+++ b/src/main/template/float/org/spongepowered/math/matrix/Matrix2{{E}}.java.peb
@@ -13,7 +13,7 @@ import org.spongepowered.math.vector.Vector2{{ E }};
 * A 2x2 matrix containing values of type {@code {{ e }}}.`
 */
 @Immutable
-public final class Matrix2{{ E }} implements Matrix{{ E }}, Serializable, Cloneable {
+public final class Matrix2{{ E }} implements Matrix{{ E }}, Serializable {
 
     private static final long serialVersionUID = 1;
     public static final Matrix2{{ E }} ZERO = new Matrix2{{ E }}(
@@ -31,12 +31,6 @@ public final class Matrix2{{ E }} implements Matrix{{ E }}, Serializable, Clonea
         this(
                 1, 0,
                 0, 1);
-    }
-
-    public Matrix2{{ E }}(final Matrix2{{ E }} m) {
-        this(
-                m.m00, m.m01,
-                m.m10, m.m11);
     }
 
     public Matrix2{{ E }}(final Matrix3{{ E }} m) {
@@ -368,11 +362,6 @@ public final class Matrix2{{ E }} implements Matrix{{ E }}, Serializable, Clonea
             this.hashed = true;
         }
         return this.hashCode;
-    }
-
-    @Override
-    public Matrix2{{ E }} clone() {
-        return new Matrix2{{ E }}(this);
     }
 
     public static Matrix2{{ E }} from(final {{ e }} n) {

--- a/src/main/template/float/org/spongepowered/math/matrix/Matrix3{{E}}.java.peb
+++ b/src/main/template/float/org/spongepowered/math/matrix/Matrix3{{E}}.java.peb
@@ -10,7 +10,7 @@ import org.spongepowered.math.vector.Vector2{{ E }};
 import org.spongepowered.math.vector.Vector3{{ E }};
 
 @Immutable
-public final class Matrix3{{ E }} implements Matrix{{ E }}, Serializable, Cloneable {
+public final class Matrix3{{ E }} implements Matrix{{ E }}, Serializable {
 
     private static final long serialVersionUID = 1;
     public static final Matrix3{{ E }} ZERO = new Matrix3{{ E }}(
@@ -40,14 +40,6 @@ public final class Matrix3{{ E }} implements Matrix{{ E }}, Serializable, Clonea
             m.get(0, 0), m.get(0, 1), 0,
             m.get(1, 0), m.get(1, 1), 0,
             0, 0, 0
-        );
-    }
-
-    public Matrix3{{ E }}(final Matrix3{{ E }} m) {
-        this(
-            m.m00, m.m01, m.m02,
-            m.m10, m.m11, m.m12,
-            m.m20, m.m21, m.m22
         );
     }
 
@@ -472,11 +464,6 @@ public final class Matrix3{{ E }} implements Matrix{{ E }}, Serializable, Clonea
             this.hashed = true;
         }
         return this.hashCode;
-    }
-
-    @Override
-    public Matrix3{{ E }} clone() {
-        return new Matrix3{{ E }}(this);
     }
 
     public static Matrix3{{ E }} from(final {{ e }} n) {

--- a/src/main/template/float/org/spongepowered/math/matrix/Matrix3{{E}}.java.peb
+++ b/src/main/template/float/org/spongepowered/math/matrix/Matrix3{{E}}.java.peb
@@ -18,7 +18,11 @@ public final class Matrix3{{ E }} implements Matrix{{ E }}, Serializable {
         0, 0, 0,
         0, 0, 0
     );
-    public static final Matrix3{{ E }} IDENTITY = new Matrix3{{ E }}();
+    public static final Matrix3{{ E }} IDENTITY = new Matrix3{{ E }}(
+        1, 0, 0,
+        0, 1, 0,
+        0, 0, 1
+    );
     private final {{ e }} m00, m01, m02;
     private final {{ e }} m10, m11, m12;
     private final {{ e }} m20, m21, m22;
@@ -26,14 +30,6 @@ public final class Matrix3{{ E }} implements Matrix{{ E }}, Serializable {
     private transient volatile boolean hashed = false;
     @SuppressWarnings("Immutable")
     private transient volatile int hashCode = 0;
-
-    public Matrix3{{ E }}() {
-        this(
-            1, 0, 0,
-            0, 1, 0,
-            0, 0, 1
-        );
-    }
 
     public Matrix3{{ E }}(final Matrix2{{ E }} m) {
         this(

--- a/src/main/template/float/org/spongepowered/math/matrix/Matrix4{{E}}.java.peb
+++ b/src/main/template/float/org/spongepowered/math/matrix/Matrix4{{E}}.java.peb
@@ -12,7 +12,7 @@ import org.spongepowered.math.vector.Vector3{{ E }};
 import org.spongepowered.math.vector.Vector4{{ E }};
 
 @Immutable
-public final class Matrix4{{ E }} implements Matrix{{ E }}, Serializable, Cloneable {
+public final class Matrix4{{ E }} implements Matrix{{ E }}, Serializable {
 
     private static final long serialVersionUID = 1;
     public static final Matrix4{{ E }} ZERO = new Matrix4{{ E }}(
@@ -53,14 +53,6 @@ public final class Matrix4{{ E }} implements Matrix{{ E }}, Serializable, Clonea
                 m.get(1, 0), m.get(1, 1), m.get(1, 2), 0,
                 m.get(2, 0), m.get(2, 1), m.get(2, 2), 0,
                 0, 0, 0, 0);
-    }
-
-    public Matrix4{{ E }}(final Matrix4{{ E }} m) {
-        this(
-                m.m00, m.m01, m.m02, m.m03,
-                m.m10, m.m11, m.m12, m.m13,
-                m.m20, m.m21, m.m22, m.m23,
-                m.m30, m.m31, m.m32, m.m33);
     }
 
     public Matrix4{{ E }}(final MatrixN{{ E }} m) {
@@ -597,11 +589,6 @@ public final class Matrix4{{ E }} implements Matrix{{ E }}, Serializable, Clonea
             this.hashed = true;
         }
         return this.hashCode;
-    }
-
-    @Override
-    public Matrix4{{ E }} clone() {
-        return new Matrix4{{ E }}(this);
     }
 
     public static Matrix4{{ E }} from(final {{ e }} n) {

--- a/src/main/template/float/org/spongepowered/math/matrix/Matrix4{{E}}.java.peb
+++ b/src/main/template/float/org/spongepowered/math/matrix/Matrix4{{E}}.java.peb
@@ -21,7 +21,12 @@ public final class Matrix4{{ E }} implements Matrix{{ E }}, Serializable {
         0, 0, 0, 0,
         0, 0, 0, 0
     );
-    public static final Matrix4{{ E }} IDENTITY = new Matrix4{{ E }}();
+    public static final Matrix4{{ E }} IDENTITY = new Matrix4{{ E }}(
+        1, 0, 0, 0,
+        0, 1, 0, 0,
+        0, 0, 1, 0,
+        0, 0, 0, 1
+    );
     private final {{ e }} m00, m01, m02, m03;
     private final {{ e }} m10, m11, m12, m13;
     private final {{ e }} m20, m21, m22, m23;
@@ -30,14 +35,6 @@ public final class Matrix4{{ E }} implements Matrix{{ E }}, Serializable {
     private transient volatile boolean hashed = false;
     @SuppressWarnings("Immutable")
     private transient volatile int hashCode = 0;
-
-    public Matrix4{{ E }}() {
-        this(
-                1, 0, 0, 0,
-                0, 1, 0, 0,
-                0, 0, 1, 0,
-                0, 0, 0, 1);
-    }
 
     public Matrix4{{ E }}(final Matrix2{{ E }} m) {
         this(

--- a/src/main/template/float/org/spongepowered/math/vector/Vector2{{E}}.java.peb
+++ b/src/main/template/float/org/spongepowered/math/vector/Vector2{{E}}.java.peb
@@ -10,7 +10,7 @@ import org.spongepowered.math.HashFunctions;
 import org.spongepowered.math.TrigMath;
 
 @Immutable
-public final class Vector2{{ E }} implements Vector{{ E }}, Comparable<Vector2{{ E }}>, Serializable, Cloneable {
+public final class Vector2{{ E }} implements Vector{{ E }}, Comparable<Vector2{{ E }}>, Serializable {
 
     private static final long serialVersionUID = 1;
     public static final Vector2{{ E }} ZERO = new Vector2{{ E }}(0, 0);
@@ -26,10 +26,6 @@ public final class Vector2{{ E }} implements Vector{{ E }}, Comparable<Vector2{{
 
     public Vector2{{ E }}() {
         this(0, 0);
-    }
-
-    public Vector2{{ E }}(final Vector2{{ E }} v) {
-        this(v.x, v.y);
     }
 
     public Vector2{{ E }}(final Vector3{{ E }} v) {
@@ -371,11 +367,6 @@ public final class Vector2{{ E }} implements Vector{{ E }}, Comparable<Vector2{{
             this.hashed = true;
         }
         return this.hashCode;
-    }
-
-    @Override
-    public Vector2{{ E }} clone() {
-        return new Vector2{{ E }}(this);
     }
 
     @Override

--- a/src/main/template/float/org/spongepowered/math/vector/Vector2{{E}}.java.peb
+++ b/src/main/template/float/org/spongepowered/math/vector/Vector2{{E}}.java.peb
@@ -24,10 +24,6 @@ public final class Vector2{{ E }} implements Vector{{ E }}, Comparable<Vector2{{
     @SuppressWarnings("Immutable")
     private transient volatile int hashCode = 0;
 
-    public Vector2{{ E }}() {
-        this(0, 0);
-    }
-
     public Vector2{{ E }}(final Vector3{{ E }} v) {
         this(v.x(), v.y());
     }

--- a/src/main/template/float/org/spongepowered/math/vector/Vector3{{E}}.java.peb
+++ b/src/main/template/float/org/spongepowered/math/vector/Vector3{{E}}.java.peb
@@ -9,7 +9,7 @@ import org.spongepowered.math.HashFunctions;
 import org.spongepowered.math.TrigMath;
 
 @Immutable
-public final class Vector3{{ E }} implements Vector{{ E }}, Comparable<Vector3{{ E }}>, Serializable, Cloneable {
+public final class Vector3{{ E }} implements Vector{{ E }}, Comparable<Vector3{{ E }}>, Serializable {
 
     private static final long serialVersionUID = 1;
     public static final Vector3{{ E }} ZERO = new Vector3{{ E }}(0, 0, 0);
@@ -42,10 +42,6 @@ public final class Vector3{{ E }} implements Vector{{ E }}, Comparable<Vector3{{
 
     public Vector3{{ E }}(final Vector2{{ E }} v, final {{ e }} z) {
         this(v.x(), v.y(), z);
-    }
-
-    public Vector3{{ E }}(final Vector3{{ E }} v) {
-        this(v.x, v.y, v.z);
     }
 
     public Vector3{{ E }}(final Vector4{{ E }} v) {
@@ -405,11 +401,6 @@ public final class Vector3{{ E }} implements Vector{{ E }}, Comparable<Vector3{{
             this.hashed = true;
         }
         return this.hashCode;
-    }
-
-    @Override
-    public Vector3{{ E }} clone() {
-        return new Vector3{{ E }}(this);
     }
 
     @Override

--- a/src/main/template/float/org/spongepowered/math/vector/Vector3{{E}}.java.peb
+++ b/src/main/template/float/org/spongepowered/math/vector/Vector3{{E}}.java.peb
@@ -28,10 +28,6 @@ public final class Vector3{{ E }} implements Vector{{ E }}, Comparable<Vector3{{
     @SuppressWarnings("Immutable")
     private transient volatile int hashCode = 0;
 
-    public Vector3{{ E }}() {
-        this(0, 0, 0);
-    }
-
     public Vector3{{ E }}(final Vector2{{ E }} v) {
         this(v, 0);
     }

--- a/src/main/template/float/org/spongepowered/math/vector/Vector4{{E}}.java.peb
+++ b/src/main/template/float/org/spongepowered/math/vector/Vector4{{E}}.java.peb
@@ -7,7 +7,7 @@ import org.spongepowered.math.GenericMath;
 import org.spongepowered.math.HashFunctions;
 
 @Immutable
-public final class Vector4{{ E }} implements Vector{{ E }}, Comparable<Vector4{{ E }}>, Serializable, Cloneable {
+public final class Vector4{{ E }} implements Vector{{ E }}, Comparable<Vector4{{ E }}>, Serializable {
 
     private static final long serialVersionUID = 1;
     public static final Vector4{{ E }} ZERO = new Vector4{{ E }}(0, 0, 0, 0);
@@ -51,10 +51,6 @@ public final class Vector4{{ E }} implements Vector{{ E }}, Comparable<Vector4{{
 
     public Vector4{{ E }}(final Vector3{{ E }} v, final {{ e }} w) {
         this(v.x(), v.y(), v.z(), w);
-    }
-
-    public Vector4{{ E }}(final Vector4{{ E }} v) {
-        this(v.x, v.y, v.z, v.w);
     }
 
     public Vector4{{ E }}(final VectorN{{ E }} v) {
@@ -426,11 +422,6 @@ public final class Vector4{{ E }} implements Vector{{ E }}, Comparable<Vector4{{
             this.hashed = true;
         }
         return this.hashCode;
-    }
-
-    @Override
-    public Vector4{{ E }} clone() {
-        return new Vector4{{ E }}(this);
     }
 
     @Override

--- a/src/main/template/float/org/spongepowered/math/vector/Vector4{{E}}.java.peb
+++ b/src/main/template/float/org/spongepowered/math/vector/Vector4{{E}}.java.peb
@@ -25,10 +25,6 @@ public final class Vector4{{ E }} implements Vector{{ E }}, Comparable<Vector4{{
     @SuppressWarnings("Immutable")
     private transient volatile int hashCode = 0;
 
-    public Vector4{{ E }}() {
-        this(0, 0, 0, 0);
-    }
-
     public Vector4{{ E }}(final Vector2{{ E }} v) {
         this(v, 0, 0);
     }

--- a/src/main/template/integer/org/spongepowered/math/vector/Vector2{{E}}.java.peb
+++ b/src/main/template/integer/org/spongepowered/math/vector/Vector2{{E}}.java.peb
@@ -20,10 +20,6 @@ public final class Vector2{{ E }} implements Vector{{ E }}, Comparable<Vector2{{
     @SuppressWarnings("Immutable")
     private transient volatile int hashCode = 0;
 
-    public Vector2{{ E }}() {
-        this(0, 0);
-    }
-
     public Vector2{{ E }}(final Vector3{{ E }} v) {
         this(v.x(), v.y());
     }

--- a/src/main/template/integer/org/spongepowered/math/vector/Vector2{{E}}.java.peb
+++ b/src/main/template/integer/org/spongepowered/math/vector/Vector2{{E}}.java.peb
@@ -6,7 +6,7 @@ import com.google.errorprone.annotations.Immutable;
 import org.spongepowered.math.GenericMath;
 
 @Immutable
-public final class Vector2{{ E }} implements Vector{{ E }}, Comparable<Vector2{{ E }}>, Serializable, Cloneable {
+public final class Vector2{{ E }} implements Vector{{ E }}, Comparable<Vector2{{ E }}>, Serializable {
 
     private static final long serialVersionUID = 1;
     public static final Vector2{{ E }} ZERO = new Vector2{{ E }}(0, 0);
@@ -22,10 +22,6 @@ public final class Vector2{{ E }} implements Vector{{ E }}, Comparable<Vector2{{
 
     public Vector2{{ E }}() {
         this(0, 0);
-    }
-
-    public Vector2{{ E }}(final Vector2{{ E }} v) {
-        this(v.x, v.y);
     }
 
     public Vector2{{ E }}(final Vector3{{ E }} v) {
@@ -335,11 +331,6 @@ public final class Vector2{{ E }} implements Vector{{ E }}, Comparable<Vector2{{
             this.hashed = true;
         }
         return this.hashCode;
-    }
-
-    @Override
-    public Vector2{{ E }} clone() {
-        return new Vector2{{ E }}(this);
     }
 
     @Override

--- a/src/main/template/integer/org/spongepowered/math/vector/Vector3{{E}}.java.peb
+++ b/src/main/template/integer/org/spongepowered/math/vector/Vector3{{E}}.java.peb
@@ -8,7 +8,7 @@ import com.google.errorprone.annotations.Immutable;
 import org.spongepowered.math.GenericMath;
 
 @Immutable
-public final class Vector3{{ E }} implements Vector{{ E }}, Comparable<Vector3{{ E }}>, Serializable, Cloneable {
+public final class Vector3{{ E }} implements Vector{{ E }}, Comparable<Vector3{{ E }}>, Serializable {
 
     private static final long serialVersionUID = 1;
     public static final Vector3{{ E }} ZERO = new Vector3{{ E }}(0, 0, 0);
@@ -41,10 +41,6 @@ public final class Vector3{{ E }} implements Vector{{ E }}, Comparable<Vector3{{
 
     public Vector3{{ E }}(final Vector2{{ E }} v, final {{ e }} z) {
         this(v.x(), v.y(), z);
-    }
-
-    public Vector3{{ E }}(final Vector3{{ E }} v) {
-        this(v.x, v.y, v.z);
     }
 
     public Vector3{{ E }}(final Vector4{{ E }} v) {
@@ -366,11 +362,6 @@ public final class Vector3{{ E }} implements Vector{{ E }}, Comparable<Vector3{{
             this.hashed = true;
         }
         return this.hashCode;
-    }
-
-    @Override
-    public Vector3{{ E }} clone() {
-        return new Vector3{{ E }}(this);
     }
 
     @Override

--- a/src/main/template/integer/org/spongepowered/math/vector/Vector3{{E}}.java.peb
+++ b/src/main/template/integer/org/spongepowered/math/vector/Vector3{{E}}.java.peb
@@ -27,10 +27,6 @@ public final class Vector3{{ E }} implements Vector{{ E }}, Comparable<Vector3{{
     @SuppressWarnings("Immutable")
     private transient volatile int hashCode = 0;
 
-    public Vector3{{ E }}() {
-        this(0, 0, 0);
-    }
-
     public Vector3{{ E }}(final Vector2{{ E }} v) {
         this(v, 0);
     }

--- a/src/main/template/integer/org/spongepowered/math/vector/Vector4{{E}}.java.peb
+++ b/src/main/template/integer/org/spongepowered/math/vector/Vector4{{E}}.java.peb
@@ -6,7 +6,7 @@ import com.google.errorprone.annotations.Immutable;
 import org.spongepowered.math.GenericMath;
 
 @Immutable
-public final class Vector4{{ E }} implements Vector{{ E }}, Comparable<Vector4{{ E }}>, Serializable, Cloneable {
+public final class Vector4{{ E }} implements Vector{{ E }}, Comparable<Vector4{{ E }}>, Serializable {
 
     private static final long serialVersionUID = 1;
     public static final Vector4{{ E }} ZERO = new Vector4{{ E }}(0, 0, 0, 0);
@@ -50,10 +50,6 @@ public final class Vector4{{ E }} implements Vector{{ E }}, Comparable<Vector4{{
 
     public Vector4{{ E }}(final Vector3{{ E }} v, final {{ e }} w) {
         this(v.x(), v.y(), v.z(), w);
-    }
-
-    public Vector4{{ E }}(final Vector4{{ E }} v) {
-        this(v.x, v.y, v.z, v.w);
     }
 
     public Vector4{{ E }}(final VectorN{{ E }} v) {
@@ -386,11 +382,6 @@ public final class Vector4{{ E }} implements Vector{{ E }}, Comparable<Vector4{{
             this.hashed = true;
         }
         return this.hashCode;
-    }
-
-    @Override
-    public Vector4{{ E }} clone() {
-        return new Vector4{{ E }}(this);
     }
 
     @Override

--- a/src/main/template/integer/org/spongepowered/math/vector/Vector4{{E}}.java.peb
+++ b/src/main/template/integer/org/spongepowered/math/vector/Vector4{{E}}.java.peb
@@ -24,10 +24,6 @@ public final class Vector4{{ E }} implements Vector{{ E }}, Comparable<Vector4{{
     @SuppressWarnings("Immutable")
     private transient volatile int hashCode = 0;
 
-    public Vector4{{ E }}() {
-        this(0, 0, 0, 0);
-    }
-
     public Vector4{{ E }}(final Vector2{{ E }} v) {
         this(v, 0, 0);
     }

--- a/src/test/template/float/com/flowpowered/math/test/imaginary/Complex{{E}}Test.java.peb
+++ b/src/test/template/float/com/flowpowered/math/test/imaginary/Complex{{E}}Test.java.peb
@@ -13,8 +13,8 @@ import org.spongepowered.math.vector.Vector3{{ E }};
 public class Complex{{ E }}Test {
 
     @Test
-    void testDefaultConstructor() {
-        final Complex{{ E }} complex = new Complex{{ E }}();
+    void testIdentity() {
+        final Complex{{ E }} complex = Complex{{ E }}.IDENTITY;
         TestUtil{{ E }}.assertEquals(complex, 1, 0);
     }
 

--- a/src/test/template/float/com/flowpowered/math/test/imaginary/Complex{{E}}Test.java.peb
+++ b/src/test/template/float/com/flowpowered/math/test/imaginary/Complex{{E}}Test.java.peb
@@ -31,12 +31,6 @@ public class Complex{{ E }}Test {
     }
 
     @Test
-    void testCopyConstructor() {
-        final Complex{{ E }} complex = new Complex{{ E }}(new Complex{{ E }}(2, 3));
-        TestUtil{{ E }}.assertEquals(complex, 2, 3);
-    }
-
-    @Test
     void testGetters() {
         final Complex{{ E }} complex = new Complex{{ E }}(2, 3);
         TestUtil{{ E }}.assertEquals(complex.x(), 2);
@@ -290,12 +284,6 @@ public class Complex{{ E }}Test {
         Assertions.assertTrue(c3 > 0);
         final int c4 = new Complex{{ E }}(0.2, 0.2).compareTo(new Complex{{ E }}(0.1, 0.1));
         Assertions.assertTrue(c4 > 0);
-    }
-
-    @Test
-    void testCloning() {
-        final Complex{{ E }} complex = new Complex{{ E }}(3, 2);
-        Assertions.assertEquals(complex, complex.clone());
     }
 
     @Test

--- a/src/test/template/float/com/flowpowered/math/test/imaginary/Quaternion{{E}}Test.java.peb
+++ b/src/test/template/float/com/flowpowered/math/test/imaginary/Quaternion{{E}}Test.java.peb
@@ -32,12 +32,6 @@ public class Quaternion{{ E }}Test {
     }
 
     @Test
-    void testCopyConstructor() {
-        final Quaternion{{ E }} quaternion = new Quaternion{{ E }}(new Quaternion{{ E }}(1, 2, 3, 4));
-        TestUtil{{ E }}.assertEquals(quaternion, 1, 2, 3, 4);
-    }
-
-    @Test
     void testGetters() {
         final Quaternion{{ E }} quaternion = new Quaternion{{ E }}(1, 2, 3, 4);
         TestUtil{{ E }}.assertEquals(quaternion.x(), 1);
@@ -293,12 +287,6 @@ public class Quaternion{{ E }}Test {
         Assertions.assertTrue(c3 > 0);
         final int c4 = new Quaternion{{ E }}(0.2, 0.2, 0.2, 0.2).compareTo(new Quaternion{{ E }}(0.1, 0.1, 0.1, 0.1));
         Assertions.assertTrue(c4 > 0);
-    }
-
-    @Test
-    void testCloning() {
-        final Quaternion{{ E }} quaternion = new Quaternion{{ E }}(3, 2, 5, 6);
-        Assertions.assertEquals(quaternion, quaternion.clone());
     }
 
     @Test

--- a/src/test/template/float/com/flowpowered/math/test/imaginary/Quaternion{{E}}Test.java.peb
+++ b/src/test/template/float/com/flowpowered/math/test/imaginary/Quaternion{{E}}Test.java.peb
@@ -14,8 +14,8 @@ import static org.spongepowered.math.test.TestUtil{{ E }}.SQRT54;
 
 public class Quaternion{{ E }}Test {
     @Test
-    void testDefaultConstructor() {
-        final Quaternion{{ E }} quaternion = new Quaternion{{ E }}();
+    void testIdentity() {
+        final Quaternion{{ E }} quaternion = Quaternion{{ E }}.IDENTITY;
         TestUtil{{ E }}.assertEquals(quaternion, 0, 0, 0, 1);
     }
 

--- a/src/test/template/float/com/flowpowered/math/test/matrix/Matrix2{{E}}Test.java.peb
+++ b/src/test/template/float/com/flowpowered/math/test/matrix/Matrix2{{E}}Test.java.peb
@@ -15,8 +15,8 @@ import static org.spongepowered.math.test.TestUtil{{ E }}.SQRT13;
 public class Matrix2{{ E }}Test {
 
     @Test
-    void testDefaultConstructor() {
-        final Matrix2{{ E }} matrix = new Matrix2{{ E }}();
+    void testIdentity() {
+        final Matrix2{{ E }} matrix = Matrix2{{ E }}.IDENTITY;
         TestUtil{{ E }}.assertEquals(matrix, 1, 0, 0, 1);
     }
 

--- a/src/test/template/float/com/flowpowered/math/test/matrix/Matrix2{{E}}Test.java.peb
+++ b/src/test/template/float/com/flowpowered/math/test/matrix/Matrix2{{E}}Test.java.peb
@@ -21,12 +21,6 @@ public class Matrix2{{ E }}Test {
     }
 
     @Test
-    void testCopyMatrix2Constructor() {
-        final Matrix2{{ E }} matrix = new Matrix2{{ E }}(new Matrix2{{ E }}(1, 2, 3, 4));
-        TestUtil{{ E }}.assertEquals(matrix, 1, 2, 3, 4);
-    }
-
-    @Test
     void testCopyMatrix3Constructor() {
         final Matrix2{{ E }} matrix = new Matrix2{{ E }}(new Matrix3{{ E }}(1, 2, 3, 4, 5, 6, 7, 8, 9));
         TestUtil{{ E }}.assertEquals(matrix, 1, 2, 4, 5);
@@ -294,12 +288,6 @@ public class Matrix2{{ E }}Test {
     void testEquals() {
         Assertions.assertTrue(new Matrix2{{ E }}(1, 2, 3, 4).equals(new Matrix2{{ E }}(1, 2, 3, 4)));
         Assertions.assertFalse(new Matrix2{{ E }}(1, 2, 3, 4).equals(new Matrix2{{ E }}(1, 2, 3, 5)));
-    }
-
-    @Test
-    void testCloning() {
-        final Matrix2{{ E }} matrix = new Matrix2{{ E }}(1, 2, 3, 4);
-        Assertions.assertEquals(matrix, matrix.clone());
     }
 
     @Test

--- a/src/test/template/float/com/flowpowered/math/test/matrix/Matrix3{{E}}Test.java.peb
+++ b/src/test/template/float/com/flowpowered/math/test/matrix/Matrix3{{E}}Test.java.peb
@@ -29,12 +29,6 @@ public class Matrix3{{ E }}Test {
     }
 
     @Test
-    void testCopyMatrix3Constructor() {
-        final Matrix3{{ E }} matrix = new Matrix3{{ E }}(new Matrix3{{ E }}(1, 2, 3, 4, 5, 6, 7, 8, 9));
-        TestUtil{{ E }}.assertEquals(matrix, 1, 2, 3, 4, 5, 6, 7, 8, 9);
-    }
-
-    @Test
     void testCopyMatrix4Constructor() {
         final Matrix3{{ E }} matrix = new Matrix3{{ E }}(new Matrix4{{ E }}(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16));
         TestUtil{{ E }}.assertEquals(matrix, 1, 2, 3, 5, 6, 7, 9, 10, 11);
@@ -332,12 +326,6 @@ public class Matrix3{{ E }}Test {
     void testEquals() {
         Assertions.assertEquals(new Matrix3{{ E }}(1, 2, 3, 4, 5, 6, 7, 8, 9), new Matrix3{{ E }}(1, 2, 3, 4, 5, 6, 7, 8, 9));
         Assertions.assertNotEquals(new Matrix3{{ E }}(1, 2, 3, 4, 5, 6, 7, 8, 9), new Matrix3{{ E }}(1, 2, 3, 4, 5, 6, 7, 8, 0));
-    }
-
-    @Test
-    void testCloning() {
-        final Matrix3{{ E }} matrix = new Matrix3{{ E }}(1, 2, 3, 4, 5, 6, 7, 8, 9);
-        Assertions.assertEquals(matrix, matrix.clone());
     }
 
     @Test

--- a/src/test/template/float/com/flowpowered/math/test/matrix/Matrix3{{E}}Test.java.peb
+++ b/src/test/template/float/com/flowpowered/math/test/matrix/Matrix3{{E}}Test.java.peb
@@ -17,8 +17,8 @@ import static org.spongepowered.math.test.TestUtil{{ E }}.SQRT13;
 public class Matrix3{{ E }}Test {
 
     @Test
-    void testDefaultConstructor() {
-        final Matrix3{{ E }} matrix = new Matrix3{{ E }}();
+    void testIdentity() {
+        final Matrix3{{ E }} matrix = Matrix3{{ E }}.IDENTITY;
         TestUtil{{ E }}.assertEquals(matrix, 1, 0, 0, 0, 1, 0, 0, 0, 1);
     }
 

--- a/src/test/template/float/com/flowpowered/math/test/matrix/Matrix4{{E}}Test.java.peb
+++ b/src/test/template/float/com/flowpowered/math/test/matrix/Matrix4{{E}}Test.java.peb
@@ -46,20 +46,6 @@ public class Matrix4{{ E }}Test {
     }
 
     @Test
-    void testCopyMatrix4Constructor() {
-        final Matrix4{{ E }} matrix = new Matrix4{{ E }}(new Matrix4{{ E }}(
-                1, 2, 3, 4,
-                5, 6, 7, 8,
-                9, 10, 11, 12,
-                13, 14, 15, 16));
-        TestUtil{{ E }}.assertEquals(matrix,
-                1, 2, 3, 4,
-                5, 6, 7, 8,
-                9, 10, 11, 12,
-                13, 14, 15, 16);
-    }
-
-    @Test
     void testCopyMatrixNConstructor() {
         final Matrix4{{ E }} matrix = new Matrix4{{ E }}(new MatrixN{{ E }}(
                 1, 2, 3, 4,
@@ -741,16 +727,6 @@ public class Matrix4{{ E }}Test {
                 0, 7, 3, 0,
                 0, 0, 0, 4);
         Assertions.assertNotEquals(matrix11, matrix12);
-    }
-
-    @Test
-    void testCloning() {
-        final Matrix4{{ E }} matrix = new Matrix4{{ E }}(
-                1, 2, 3, 4,
-                0, 2, 0, 0,
-                0, 0, 3, 0,
-                0, 0, 0, 4);
-        Assertions.assertEquals(matrix, matrix.clone());
     }
 
     @Test

--- a/src/test/template/float/com/flowpowered/math/test/matrix/Matrix4{{E}}Test.java.peb
+++ b/src/test/template/float/com/flowpowered/math/test/matrix/Matrix4{{E}}Test.java.peb
@@ -16,8 +16,8 @@ import static org.spongepowered.math.test.TestUtil{{ E }}.SQRT13;
 
 public class Matrix4{{ E }}Test {
     @Test
-    void testDefaultConstructor() {
-        final Matrix4{{ E }} matrix = new Matrix4{{ E }}();
+    void testIdentity() {
+        final Matrix4{{ E }} matrix = Matrix4{{ E }}.IDENTITY;
         TestUtil{{ E }}.assertEquals(matrix,
                 1, 0, 0, 0,
                 0, 1, 0, 0,

--- a/src/test/template/float/com/flowpowered/math/test/vector/Vector2{{E}}Test.java.peb
+++ b/src/test/template/float/com/flowpowered/math/test/vector/Vector2{{E}}Test.java.peb
@@ -21,12 +21,6 @@ public class Vector2{{ E }}Test {
     }
 
     @Test
-    void testCopyVector2Constructor() {
-        final Vector2{{ E }} vector = new Vector2{{ E }}(new Vector2{{ E }}(0, 1));
-        TestUtil{{ E }}.assertEquals(vector, 0, 1);
-    }
-
-    @Test
     void testCopyVector3Constructor() {
         final Vector2{{ E }} vector = new Vector2{{ E }}(new Vector3{{ E }}(0, 1, 2));
         TestUtil{{ E }}.assertEquals(vector, 0, 1);
@@ -417,12 +411,6 @@ public class Vector2{{ E }}Test {
     void testEquals() {
         Assertions.assertTrue(new Vector2{{ E }}(122, 43).equals(new Vector2{{ E }}(122, 43)));
         Assertions.assertFalse(new Vector2{{ E }}(122, 43).equals(new Vector2{{ E }}(378, 95)));
-    }
-
-    @Test
-    void testCloning() {
-        final Vector2{{ E }} vector = new Vector2{{ E }}(3, 2);
-        Assertions.assertEquals(vector, vector.clone());
     }
 
     @Test

--- a/src/test/template/float/com/flowpowered/math/test/vector/Vector2{{E}}Test.java.peb
+++ b/src/test/template/float/com/flowpowered/math/test/vector/Vector2{{E}}Test.java.peb
@@ -15,8 +15,8 @@ import org.spongepowered.math.vector.VectorN{{ E }};
 public class Vector2{{ E }}Test {
 
     @Test
-    void testEmptyConstructor() {
-        final Vector2{{ E }} vector = new Vector2{{ E }}();
+    void testZero() {
+        final Vector2{{ E }} vector = Vector2{{ E }}.ZERO;
         TestUtil{{ E }}.assertEquals(vector, 0, 0);
     }
 

--- a/src/test/template/float/com/flowpowered/math/test/vector/Vector3{{E}}Test.java.peb
+++ b/src/test/template/float/com/flowpowered/math/test/vector/Vector3{{E}}Test.java.peb
@@ -40,12 +40,6 @@ public class Vector3{{ E }}Test {
     }
 
     @Test
-    void testCopyVector3Constructor() {
-        final Vector3{{ E }} vector = new Vector3{{ E }}(new Vector3{{ E }}(0, 1, 2));
-        TestUtil{{ E }}.assertEquals(vector, 0, 1, 2);
-    }
-
-    @Test
     void testCopyVector4Constructor() {
         final Vector3{{ E }} vector = new Vector3{{ E }}(new Vector4{{ E }}(0, 1, 2, 3));
         TestUtil{{ E }}.assertEquals(vector, 0, 1, 2);
@@ -442,12 +436,6 @@ public class Vector3{{ E }}Test {
     void testEquals() {
         Assertions.assertTrue(new Vector3{{ E }}(122, 43, 96).equals(new Vector3{{ E }}(122, 43, 96)));
         Assertions.assertFalse(new Vector3{{ E }}(122, 43, 96).equals(new Vector3{{ E }}(378, 95, 96)));
-    }
-
-    @Test
-    void testCloning() {
-        final Vector3{{ E }} vector = new Vector3{{ E }}(3, 2, 5);
-        Assertions.assertEquals(vector, vector.clone());
     }
 
     @Test

--- a/src/test/template/float/com/flowpowered/math/test/vector/Vector3{{E}}Test.java.peb
+++ b/src/test/template/float/com/flowpowered/math/test/vector/Vector3{{E}}Test.java.peb
@@ -16,8 +16,8 @@ import org.spongepowered.math.vector.VectorN{{ E }};
 
 public class Vector3{{ E }}Test {
     @Test
-    void testEmptyConstructor() {
-        final Vector3{{ E }} vector = new Vector3{{ E }}();
+    void testZero() {
+        final Vector3{{ E }} vector = Vector3{{ E }}.ZERO;
         TestUtil{{ E }}.assertEquals(vector, 0, 0, 0);
     }
 

--- a/src/test/template/float/com/flowpowered/math/test/vector/Vector4{{E}}Test.java.peb
+++ b/src/test/template/float/com/flowpowered/math/test/vector/Vector4{{E}}Test.java.peb
@@ -14,8 +14,8 @@ import org.spongepowered.math.vector.VectorN{{ E }};
 public class Vector4{{ E }}Test {
 
     @Test
-    void testEmptyConstructor() {
-        final Vector4{{ E }} vector = new Vector4{{ E }}();
+    void testZero() {
+        final Vector4{{ E }} vector = Vector4{{ E }}.ZERO;
         TestUtil{{ E }}.assertEquals(vector, 0, 0, 0, 0);
     }
 

--- a/src/test/template/float/com/flowpowered/math/test/vector/Vector4{{E}}Test.java.peb
+++ b/src/test/template/float/com/flowpowered/math/test/vector/Vector4{{E}}Test.java.peb
@@ -56,12 +56,6 @@ public class Vector4{{ E }}Test {
     }
 
     @Test
-    void testCopyVector4Constructor() {
-        final Vector4{{ E }} vector = new Vector4{{ E }}(new Vector4{{ E }}(0, 1, 1, 2));
-        TestUtil{{ E }}.assertEquals(vector, 0, 1, 1, 2);
-    }
-
-    @Test
     void testCopyVectorNConstructor() {
         final Vector4{{ E }} vector = new Vector4{{ E }}(new VectorN{{ E }}(0, 1, 1, 2, 5));
         TestUtil{{ E }}.assertEquals(vector, 0, 1, 1, 2);
@@ -430,12 +424,6 @@ public class Vector4{{ E }}Test {
     void testEquals() {
         Assertions.assertTrue(new Vector4{{ E }}(122, 43, 96, 50).equals(new Vector4{{ E }}(122, 43, 96, 50)));
         Assertions.assertFalse(new Vector4{{ E }}(122, 43, 96, 50).equals(new Vector4{{ E }}(378, 95, 96, 0)));
-    }
-
-    @Test
-    void testCloning() {
-        final Vector4{{ E }} vector = new Vector4{{ E }}(3, 2, 5, 6);
-        Assertions.assertEquals(vector, vector.clone());
     }
 
     @Test

--- a/src/test/template/float/com/flowpowered/math/test/vector/VectorN{{E}}Test.java.peb
+++ b/src/test/template/float/com/flowpowered/math/test/vector/VectorN{{E}}Test.java.peb
@@ -392,4 +392,5 @@ public class VectorN{{ E }}Test {
         final VectorN{{ E }} vector = new VectorN{{ E }}(1, 2, 3);
         Assertions.assertEquals(vector, vector.clone());
     }
+
 }

--- a/src/test/template/integer/com/flowpowered/math/test/vector/Vector2{{E}}Test.java.peb
+++ b/src/test/template/integer/com/flowpowered/math/test/vector/Vector2{{E}}Test.java.peb
@@ -15,8 +15,8 @@ import org.spongepowered.math.vector.VectorN{{ E }};
 public class Vector2{{ E }}Test {
 
     @Test
-    void testEmptyConstructor() {
-        final Vector2{{ E }} vector = new Vector2{{ E }}();
+    void testZero() {
+        final Vector2{{ E }} vector = Vector2{{ E }}.ZERO;
         TestUtil{{ E }}.assertEquals(vector, ({{ e }}) 0, ({{ e }}) 0);
     }
 

--- a/src/test/template/integer/com/flowpowered/math/test/vector/Vector2{{E}}Test.java.peb
+++ b/src/test/template/integer/com/flowpowered/math/test/vector/Vector2{{E}}Test.java.peb
@@ -21,12 +21,6 @@ public class Vector2{{ E }}Test {
     }
 
     @Test
-    void testCopyVector2Constructor() {
-        final Vector2{{ E }} vector = new Vector2{{ E }}(new Vector2{{ E }}(0, 1));
-        TestUtil{{ E }}.assertEquals(vector, ({{ e }}) 0, ({{ e }}) 1);
-    }
-
-    @Test
     void testCopyVector3Constructor() {
         final Vector2{{ E }} vector = new Vector2{{ E }}(new Vector3{{ E }}(0, 1, 2));
         TestUtil{{ E }}.assertEquals(vector, ({{ e }}) 0, ({{ e }}) 1);
@@ -383,12 +377,6 @@ public class Vector2{{ E }}Test {
     void testEquals() {
         Assertions.assertTrue(new Vector2{{ E }}(122, 43).equals(new Vector2{{ E }}(122, 43)));
         Assertions.assertFalse(new Vector2{{ E }}(122, 43).equals(new Vector2{{ E }}(378, 95)));
-    }
-
-    @Test
-    void testCloning() {
-        final Vector2{{ E }} vector = new Vector2{{ E }}(3, 2);
-        Assertions.assertEquals(vector, vector.clone());
     }
 
 }

--- a/src/test/template/integer/com/flowpowered/math/test/vector/Vector3{{E}}Test.java.peb
+++ b/src/test/template/integer/com/flowpowered/math/test/vector/Vector3{{E}}Test.java.peb
@@ -33,12 +33,6 @@ public class Vector3{{ E }}Test {
     }
 
     @Test
-    void testCopyVector3Constructor() {
-        final Vector3{{ E }} vector = new Vector3{{ E }}(new Vector3{{ E }}(0, 1, 2));
-        TestUtil{{ E }}.assertEquals(vector, ({{ e }}) 0, ({{ e }}) 1, ({{ e }}) 2);
-    }
-
-    @Test
     void testCopyVector4Constructor() {
         final Vector3{{ E }} vector = new Vector3{{ E }}(new Vector4{{ E }}(0, 1, 2, 3));
         TestUtil{{ E }}.assertEquals(vector, ({{ e }}) 0, ({{ e }}) 1, ({{ e }}) 2);
@@ -400,12 +394,6 @@ public class Vector3{{ E }}Test {
     void testEquals() {
         Assertions.assertTrue(new Vector3{{ E }}(122, 43, 96).equals(new Vector3{{ E }}(122, 43, 96)));
         Assertions.assertFalse(new Vector3{{ E }}(122, 43, 96).equals(new Vector3{{ E }}(378, 95, 96)));
-    }
-
-    @Test
-    void testCloning() {
-        final Vector3{{ E }} vector = new Vector3{{ E }}(3, 2, 5);
-        Assertions.assertEquals(vector, vector.clone());
     }
 
 }

--- a/src/test/template/integer/com/flowpowered/math/test/vector/Vector3{{E}}Test.java.peb
+++ b/src/test/template/integer/com/flowpowered/math/test/vector/Vector3{{E}}Test.java.peb
@@ -15,8 +15,8 @@ import org.spongepowered.math.vector.VectorN{{ E }};
 public class Vector3{{ E }}Test {
 
     @Test
-    void testEmptyConstructor() {
-        final Vector3{{ E }} vector = new Vector3{{ E }}();
+    void testZero() {
+        final Vector3{{ E }} vector = Vector3{{ E }}.ZERO;
         TestUtil{{ E }}.assertEquals(vector, ({{ e }}) 0, ({{ e }}) 0, ({{ e }}) 0);
     }
 

--- a/src/test/template/integer/com/flowpowered/math/test/vector/Vector4{{E}}Test.java.peb
+++ b/src/test/template/integer/com/flowpowered/math/test/vector/Vector4{{E}}Test.java.peb
@@ -43,12 +43,6 @@ public class Vector4{{ E }}Test {
     }
 
     @Test
-    void testCopyVector4Constructor() {
-        final Vector4{{ E }} vector = new Vector4{{ E }}(new Vector4{{ E }}(0, 1, 1, 2));
-        TestUtil{{ E }}.assertEquals(vector, 0, 1, 1, 2);
-    }
-
-    @Test
     void testCopyVectorNConstructor() {
         final Vector4{{ E }} vector = new Vector4{{ E }}(new VectorN{{ E }}(0, 1, 1, 2, 5));
         TestUtil{{ E }}.assertEquals(vector, 0, 1, 1, 2);
@@ -379,12 +373,6 @@ public class Vector4{{ E }}Test {
     void testEquals() {
         Assertions.assertTrue(new Vector4{{ E }}(122, 43, 96, 50).equals(new Vector4{{ E }}(122, 43, 96, 50)));
         Assertions.assertFalse(new Vector4{{ E }}(122, 43, 96, 50).equals(new Vector4{{ E }}(378, 95, 96, 0)));
-    }
-
-    @Test
-    void testCloning() {
-        final Vector4{{ E }} vector = new Vector4{{ E }}(3, 2, 5, 6);
-        Assertions.assertEquals(vector, vector.clone());
     }
 
 }

--- a/src/test/template/integer/com/flowpowered/math/test/vector/Vector4{{E}}Test.java.peb
+++ b/src/test/template/integer/com/flowpowered/math/test/vector/Vector4{{E}}Test.java.peb
@@ -13,8 +13,8 @@ import org.spongepowered.math.vector.VectorN{{ E }};
 public class Vector4{{ E }}Test {
 
     @Test
-    void testEmptyConstructor() {
-        final Vector4{{ E }} vector = new Vector4{{ E }}();
+    void testZero() {
+        final Vector4{{ E }} vector = Vector4{{ E }}.ZERO;
         TestUtil{{ E }}.assertEquals(vector, 0, 0, 0, 0);
     }
 


### PR DESCRIPTION
- Immutable types are no longer Cloneable, since there's no real reason to copy them. For the same reason, copy constructors for equal types have been removed.
- Default constructors have been removed -- they are redundant with the class constants that already exist.


I'll leave this up for a little while in case there are any objections to removing this API.